### PR TITLE
Set the file name as the original one

### DIFF
--- a/app/helpers/ImageManager.js
+++ b/app/helpers/ImageManager.js
@@ -131,7 +131,7 @@ module.exports = {
 
         const storage = multer.diskStorage({
             destination: "./public/upload/",
-            filename: file.originalname,
+            filename: req.file.filename,
         });
 
         let upload = multer({

--- a/app/helpers/ImageManager.js
+++ b/app/helpers/ImageManager.js
@@ -131,9 +131,7 @@ module.exports = {
 
         const storage = multer.diskStorage({
             destination: "./public/upload/",
-            filename: function (req, file, cb) {
-                cb(null, prefix + "-" + Date.now() + path.extname(file.originalname));
-            }
+            filename: file.originalname,
         });
 
         let upload = multer({


### PR DESCRIPTION
I've changed the file name from "uploadimagebody", the only function used when uploading a CV.
I'm facing some problems while running the web app locally in the development mode. So, I couldn't test if that's the only needed change.